### PR TITLE
Fix crash with 3.2.2, correct type casting

### DIFF
--- a/addons/explore-editor-theme/tabs/EditorConstants.gd
+++ b/addons/explore-editor-theme/tabs/EditorConstants.gd
@@ -9,7 +9,7 @@ onready var constant_list : ItemList = $Layout/ConstantView/ConstantList
 onready var empty_panel : Control = $Layout/ConstantView/EmptyPanel
 onready var constant_panel : Control = $Layout/ConstantView/ConstantPanel
 onready var constant_title : Label = $Layout/ConstantView/ConstantPanel/ConstantName
-onready var constant_value : TextureRect = $Layout/ConstantView/ConstantPanel/ConstantValue
+onready var constant_value : Label = $Layout/ConstantView/ConstantPanel/ConstantValue
 onready var constant_code : Control = $Layout/ConstantView/ConstantPanel/ConstantCode
 
 # Private properties

--- a/addons/explore-editor-theme/ui/TypeTool.gd
+++ b/addons/explore-editor-theme/ui/TypeTool.gd
@@ -3,7 +3,7 @@ extends HBoxContainer
 
 # Node references
 onready var label : Label = $Label
-onready var input : LineEdit = $Input
+onready var input : OptionButton = $Input
 
 signal item_selected(index)
 


### PR DESCRIPTION
Now that Godot has been updated to 3.2.2, incorrect type casting sets the value to NULL as a result.
This results in the plugin spewing following errors into the console:

![error_editor_theme](https://user-images.githubusercontent.com/42484461/86112680-9688e180-bac8-11ea-8ac1-12316d3b7e89.PNG)


I fixed the the incorrect type casting (only two were incorrect) and now everything works nicely again.