### PR TITLE
Display icon size and color HTML code

### DIFF
--- a/addons/explore-editor-theme/tabs/EditorColors.gd
+++ b/addons/explore-editor-theme/tabs/EditorColors.gd
@@ -79,7 +79,8 @@ func _on_color_item_selected(item_index : int) -> void:
 	
 	color_preview.texture = color_texture
 	color_preview.self_modulate = color_modulate
-	color_preview_info.text = "R: " + str(color_modulate.r) + "\n"
+	color_preview_info.text = "#" + color_modulate.to_html(color_modulate.a != 1) + "\n"
+	color_preview_info.text += "R: " + str(color_modulate.r) + "\n"
 	color_preview_info.text += "G: " + str(color_modulate.g) + "\n"
 	color_preview_info.text += "B: " + str(color_modulate.b) + "\n"
 	color_preview_info.text += "A: " + str(color_modulate.a) + ""

--- a/addons/explore-editor-theme/tabs/EditorIcons.gd
+++ b/addons/explore-editor-theme/tabs/EditorIcons.gd
@@ -75,6 +75,7 @@ func _on_icon_item_selected(item_index : int) -> void:
 	var type_name = type_tool.get_selected_text()
 	
 	icon_preview.texture = icon_texture
+	icon_preview_info.text = str(icon_texture.get_width()) + "x" + str(icon_texture.get_height())
 	icon_title.text = icon_name
 	icon_code.code_text = "get_icon(\"" + icon_name + "\", \"" + type_name + "\")"
 	


### PR DESCRIPTION
* Replaces the 64x64 label with a label that displays the icon's size.
![image](https://user-images.githubusercontent.com/67974470/155832848-111919c6-a152-48cc-8dd1-885d94553fc4.png) ![image](https://user-images.githubusercontent.com/67974470/155832839-53273eb6-fc2b-4d2c-ba07-92a066109e32.png) ![image](https://user-images.githubusercontent.com/67974470/155832818-8668b511-c7ef-48e0-b984-6a625e8f4adb.png)
* Makes the color info label also show the color's HTML code.
![image](https://user-images.githubusercontent.com/67974470/155832677-bc81c325-6363-458f-9d60-fac94a8a810f.png)
